### PR TITLE
Add Gemini-based emotional analysis

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,74 @@
-import Image from "next/image";
+"use client";
+
+import { useState } from "react";
+import EmojiGrid from "@/components/EmojiGrid";
+import ExplanationBox from "@/components/ExplanationBox";
 
 export default function Home() {
-  return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [text, setText] = useState("");
+  const [grid, setGrid] = useState<string[][] | null>(null);
+  const [explanations, setExplanations] = useState<Record<string, string> | null>(null);
+  const [diagnosis, setDiagnosis] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+  const handleGenerate = async () => {
+    if (!text.trim()) return;
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=AIzaSyCnnwnkEtqt3JGKsqo82EHeVg2E4vDO7AI",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            contents: [
+              {
+                parts: [
+                  {
+                    text: `A partir del siguiente texto emocional, genera un patrón cuadrado de emojis simétrico (solo 5x5) representando el estado interior del usuario. Luego, explica el significado de cada emoji usado en una tabla. Finalmente, escribe un pequeño diagnóstico emocional.\n\nDevuelve únicamente un objeto JSON con las claves \"emojiGrid\", \"emojiExplanation\" y \"diagnosis\".\n\nTexto: ${text}`,
+                  },
+                ],
+              },
+            ],
+          }),
+        }
+      );
+      const data = await res.json();
+      const content = data.candidates?.[0]?.content?.parts?.[0]?.text;
+      const parsed = JSON.parse(content);
+      setGrid(parsed.emojiGrid);
+      setExplanations(parsed.emojiExplanation);
+      setDiagnosis(parsed.diagnosis);
+    } catch (err) {
+      console.error(err);
+      setError("No se pudo generar el diagnóstico");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="p-6 max-w-xl mx-auto space-y-6">
+      <textarea
+        className="w-full p-3 border rounded"
+        rows={4}
+        placeholder="¿Cómo te sientes hoy?"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <button
+        onClick={handleGenerate}
+        disabled={loading}
+        className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+      >
+        {loading ? "Generando..." : "Generar diagnóstico"}
+      </button>
+      {error && <p className="text-red-500">{error}</p>}
+      {grid && <EmojiGrid grid={grid} />}
+      {explanations && <ExplanationBox explanations={explanations} />}
+      {diagnosis && <p className="mt-4 text-center">{diagnosis}</p>}
+    </main>
   );
 }

--- a/src/components/EmojiGrid.tsx
+++ b/src/components/EmojiGrid.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export interface EmojiGridProps {
+  grid: string[][];
+}
+
+export default function EmojiGrid({ grid }: EmojiGridProps) {
+  if (!grid?.length) return null;
+  const flat = grid.flat();
+  const cols = grid[0].length;
+  return (
+    <div
+      className="grid gap-1 text-2xl text-center"
+      style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+    >
+      {flat.map((emoji, i) => (
+        <span key={i}>{emoji}</span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ExplanationBox.tsx
+++ b/src/components/ExplanationBox.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+export interface ExplanationBoxProps {
+  explanations: Record<string, string>;
+}
+
+export default function ExplanationBox({ explanations }: ExplanationBoxProps) {
+  const entries = Object.entries(explanations);
+  if (!entries.length) return null;
+  return (
+    <table className="table-auto border-collapse mt-4 text-sm">
+      <thead>
+        <tr>
+          <th className="px-2 py-1 border">Emoji</th>
+          <th className="px-2 py-1 border">Significado</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map(([emoji, meaning]) => (
+          <tr key={emoji}>
+            <td className="px-2 py-1 border text-center">{emoji}</td>
+            <td className="px-2 py-1 border">{meaning}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- create `EmojiGrid` and `ExplanationBox` components
- replace the main page with a text area and button to call Gemini API
- display a square emoji grid, explanations table and diagnosis text

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68585954fce8832bb8f6b97a93d8d19d