### PR TITLE
Implement custom parser for Gemini output

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import EmojiGrid from "@/components/EmojiGrid";
 import ExplanationBox from "@/components/ExplanationBox";
+import { parseGeminiResponse } from "@/lib/parseGeminiResponse";
 
 export default function Home() {
   const [text, setText] = useState("");
@@ -54,7 +55,7 @@ export default function Home() {
       }
       let parsed;
       try {
-        parsed = JSON.parse(content);
+        parsed = parseGeminiResponse(content);
       } catch (parseErr) {
         console.error(parseErr);
         throw new Error("Formato de respuesta no válido");

--- a/src/lib/parseGeminiResponse.ts
+++ b/src/lib/parseGeminiResponse.ts
@@ -1,0 +1,31 @@
+export function parseGeminiResponse(content: string) {
+  const lines = content.split('\n').map((l) => l.trim()).filter(Boolean);
+
+  const emojiGrid = lines.slice(0, 5).map((line) => line.split(/\s+/));
+
+  const explanationStart = lines.findIndex((line) =>
+    line.toLowerCase().includes('explicaci\u00f3n de los s\u00edmbolos')
+  );
+
+  const diagnosisStart = lines.findIndex(
+    (line) =>
+      line.toLowerCase().includes('¿c\u00f3mo leer esto?') || line.startsWith('🧠')
+  );
+
+  const explanationLines = lines.slice(explanationStart + 1, diagnosisStart);
+  const emojiExplanation: Record<string, string> = {};
+  explanationLines.forEach((line) => {
+    const [emoji, ...meaningParts] = line.split(/\s{2,}|\t+/);
+    if (emoji && meaningParts.length) {
+      emojiExplanation[emoji] = meaningParts.join(' ').trim();
+    }
+  });
+
+  const diagnosis = lines.slice(diagnosisStart).join(' ');
+
+  return {
+    emojiGrid,
+    emojiExplanation,
+    diagnosis,
+  };
+}


### PR DESCRIPTION
## Summary
- add `parseGeminiResponse` helper to parse non-JSON Gemini output
- use the new parser instead of `JSON.parse` in `page.tsx`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68585e97068c832ba957eedf6251ec55