### PR TITLE
Update emoji matrix and grid layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,8 +63,8 @@ export default function Home() {
   return (
     <main className="flex flex-col min-h-screen items-center justify-center p-6 space-y-4">
       {grid && (
-        <div className="bg-white rounded-lg shadow p-6">
-          <EmojiGrid grid={grid} className="text-4xl" />
+        <div className="w-[320px] h-[320px] p-4 shadow-xl bg-gray-50 rounded-2xl flex flex-col justify-center items-center">
+          <EmojiGrid grid={grid} className="gap-2 text-5xl leading-none" />
         </div>
       )}
       {error && <p className="text-red-500">{error}</p>}

--- a/src/components/EmojiGrid.tsx
+++ b/src/components/EmojiGrid.tsx
@@ -11,7 +11,7 @@ export default function EmojiGrid({ grid, className }: EmojiGridProps) {
   const cols = grid[0].length;
   return (
     <div
-      className={`grid gap-1 text-2xl text-center ${className ?? ""}`}
+      className={`grid text-center ${className ?? ""}`}
       style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
     >
       {flat.map((emoji, i) => (

--- a/src/lib/toEmojiMatrix.ts
+++ b/src/lib/toEmojiMatrix.ts
@@ -1,18 +1,27 @@
-export function toEmojiMatrix(emojiText: string, size = 5): string[][] {
-  const emojis = emojiText
-    .trim()
-    .split(/\s+/)
-    .filter((e) => e.length > 0);
+export function toEmojiMatrix(rawText: string, size = 5): string[][] {
+  // Eliminar símbolos no deseados
+  const clean = rawText.replace(/["\[\]{}',]/g, '').trim();
 
-  // Rellenar con 🟦 si faltan, cortar si sobran
+  // Separar emojis por espacios
+  const emojis = clean.split(/\s+/).filter((e) => e.length > 0);
+
   const total = size * size;
-  const padded = [...emojis.slice(0, total)];
-  while (padded.length < total) padded.push("🟦");
+  const centerIndex = Math.floor(total / 2);
 
-  // Crear matriz
+  // Rellenar repitiendo en orden
+  const filled = [...emojis];
+  while (filled.length < total) {
+    const repeatIndex = (filled.length - 1) % (emojis.length || 1);
+    filled.push(emojis[repeatIndex] || '🧿');
+  }
+
+  // Forzar 🧿 en el centro
+  filled[centerIndex] = '🧿';
+
+  // Convertir a matriz cuadrada
   const matrix = [] as string[][];
   for (let i = 0; i < size; i++) {
-    matrix.push(padded.slice(i * size, (i + 1) * size));
+    matrix.push(filled.slice(i * size, (i + 1) * size));
   }
 
   return matrix;


### PR DESCRIPTION
## Summary
- improve `toEmojiMatrix` by cleaning symbols, repeating emojis, and centering 🧿
- simplify `EmojiGrid` styles so parent components control layout
- use a square card layout with larger emojis on the homepage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68586420a90c832bb9fde2afa1f242cc