### PR TITLE
Implement mirrored symmetry layout

### DIFF
--- a/src/lib/generateSymmetricPatternSymmetric.ts
+++ b/src/lib/generateSymmetricPatternSymmetric.ts
@@ -1,0 +1,61 @@
+export function generateSymmetricPatternSymmetric(emojis: string[], size = 5): string[][] {
+  const clean = emojis.filter(e => e.length > 0);
+  if (clean.length === 0) return Array.from({ length: size }, () => Array(size).fill('❔'));
+
+  const matrix = Array.from({ length: size }, () => Array(size).fill(''));
+  const visited = Array.from({ length: size }, () => Array(size).fill(false));
+  const center = Math.floor(size / 2);
+
+  // Helper to get symmetric positions of a given coordinate
+  function getGroup(r: number, c: number): [number, number][] {
+    const coords: [number, number][] = [
+      [r, c],
+      [c, r],
+      [size - 1 - r, c],
+      [r, size - 1 - c],
+      [size - 1 - r, size - 1 - c],
+      [c, size - 1 - r],
+      [size - 1 - c, r],
+      [size - 1 - c, size - 1 - r],
+    ];
+
+    const set = new Set<string>();
+    for (const [x, y] of coords) {
+      if (x >= 0 && x < size && y >= 0 && y < size) {
+        set.add(`${x},${y}`);
+      }
+    }
+    const arr = Array.from(set).map(str => str.split(',').map(Number) as [number, number]);
+    for (const [x, y] of arr) {
+      visited[x][y] = true;
+    }
+    return arr;
+  }
+
+  const groups: [number, number][][] = [];
+
+  // First group: the center
+  visited[center][center] = true;
+  groups.push([[center, center]]);
+
+  // Build remaining groups
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      if (!visited[r][c]) {
+        groups.push(getGroup(r, c));
+      }
+    }
+  }
+
+  // Assign emojis to each symmetric group
+  let idx = 0;
+  for (const group of groups) {
+    const emoji = clean[idx % clean.length];
+    for (const [r, c] of group) {
+      matrix[r][c] = emoji;
+    }
+    idx++;
+  }
+
+  return matrix;
+}

--- a/src/lib/toEmojiMatrix.ts
+++ b/src/lib/toEmojiMatrix.ts
@@ -1,4 +1,4 @@
-import { generateSymmetricPattern } from './generateSymmetricPattern';
+import { generateSymmetricPatternSymmetric } from './generateSymmetricPatternSymmetric';
 
 export function toEmojiMatrix(rawText: string, size = 5): string[][] {
   // Eliminar símbolos no deseados
@@ -10,5 +10,5 @@ export function toEmojiMatrix(rawText: string, size = 5): string[][] {
   // Usar 🧿 como comodín si no se encontró ningún emoji
   const base = emojis.length > 0 ? emojis : ['🧿'];
 
-  return generateSymmetricPattern(base, size);
+  return generateSymmetricPatternSymmetric(base, size);
 }


### PR DESCRIPTION
## Summary
- add `generateSymmetricPatternSymmetric` that mirrors emojis across all axes
- use it from `toEmojiMatrix`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68586928b2f0832b8922ea3fe3103bfb