### PR TITLE
Add grid size toggle for emoji pattern

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,30 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import EmojiGrid from "@/components/EmojiGrid";
-import { toEmojiMatrix } from "@/lib/toEmojiMatrix";
+import { extractEmojis } from "@/lib/toEmojiMatrix";
+import { generateSymmetricPatternSymmetric } from "@/lib/generateSymmetricPatternSymmetric";
 
 export default function Home() {
   const [text, setText] = useState("");
   const [grid, setGrid] = useState<string[][] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const sizeOptions = [3, 5, 7];
+  const [sizeIndex, setSizeIndex] = useState(1); // default 5x5
+  const size = sizeOptions[sizeIndex];
+  const [emojis, setEmojis] = useState<string[]>([]);
+
+  const toggleSize = () => {
+    setSizeIndex((prev) => (prev + 1) % sizeOptions.length);
+  };
+
+  useEffect(() => {
+    if (emojis.length) {
+      const matrix = generateSymmetricPatternSymmetric(emojis, size);
+      setGrid(matrix);
+    }
+  }, [size, emojis]);
 
   const handleGenerate = async () => {
     if (!text.trim()) return;
@@ -50,7 +66,9 @@ export default function Home() {
       if (!content) {
         throw new Error("Respuesta vacía del modelo");
       }
-      const matrix = toEmojiMatrix(content);
+      const base = extractEmojis(content);
+      setEmojis(base);
+      const matrix = generateSymmetricPatternSymmetric(base.length ? base : ['🧿'], size);
       setGrid(matrix);
     } catch (err) {
       console.error(err);
@@ -65,6 +83,12 @@ export default function Home() {
       {grid && (
         <div className="w-[320px] h-[320px] p-4 shadow-xl bg-gray-50 rounded-2xl flex flex-col justify-center items-center">
           <EmojiGrid grid={grid} className="gap-2 text-5xl leading-none" />
+          <button
+            onClick={toggleSize}
+            className="mt-4 px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600"
+          >
+            Cambiar tamaño: {size}x{size}
+          </button>
         </div>
       )}
       {error && <p className="text-red-500">{error}</p>}

--- a/src/lib/toEmojiMatrix.ts
+++ b/src/lib/toEmojiMatrix.ts
@@ -1,14 +1,15 @@
 import { generateSymmetricPatternSymmetric } from './generateSymmetricPatternSymmetric';
 
-export function toEmojiMatrix(rawText: string, size = 5): string[][] {
+export function extractEmojis(rawText: string): string[] {
   // Eliminar símbolos no deseados
   const clean = rawText.replace(/["\[\]{}',]/g, '').trim();
-
   // Separar emojis por espacios
-  const emojis = clean.split(/\s+/).filter((e) => e.length > 0);
+  return clean.split(/\s+/).filter((e) => e.length > 0);
+}
 
-  // Usar 🧿 como comodín si no se encontró ningún emoji
+export function toEmojiMatrix(rawText: string, size = 5): string[][] {
+  const emojis = extractEmojis(rawText);
   const base = emojis.length > 0 ? emojis : ['🧿'];
-
+  
   return generateSymmetricPatternSymmetric(base, size);
 }


### PR DESCRIPTION
## Summary
- extract emojis with new helper function
- allow grid size toggle between 3x3, 5x5 and 7x7

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68586f9b5ab0832ba4f012edc5ce4e5d