### PR TITLE
Add multi-page layout with home page options

### DIFF
--- a/src/app/emojigrids/page.tsx
+++ b/src/app/emojigrids/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import EmojiGrid from "@/components/EmojiGrid";
+import { extractEmojis } from "@/lib/toEmojiMatrix";
+import { generateSymmetricPatternSymmetric } from "@/lib/generateSymmetricPatternSymmetric";
+
+export default function EmojiGridPage() {
+  const [text, setText] = useState("");
+  const [grid, setGrid] = useState<string[][] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const sizeOptions = [3, 5, 7];
+  const [sizeIndex, setSizeIndex] = useState(1); // default 5x5
+  const size = sizeOptions[sizeIndex];
+  const [emojis, setEmojis] = useState<string[]>([]);
+
+  const toggleSize = () => {
+    setSizeIndex((prev) => (prev + 1) % sizeOptions.length);
+  };
+
+  useEffect(() => {
+    if (emojis.length) {
+      const matrix = generateSymmetricPatternSymmetric(emojis, size);
+      setGrid(matrix);
+    }
+  }, [size, emojis]);
+
+  const handleGenerate = async () => {
+    if (!text.trim()) return;
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=AIzaSyDnO8MO4qFgkOcSO2eHVZkfQ7cZ2KhrA5I",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            contents: [
+              {
+                parts: [
+                  {
+                    text: `Traduce el siguiente texto a la mayor cantidad posible de emojis apropiados. No expliques nada. Solo responde con emojis separados por espacios:\n\nTexto: ${text}`,
+                  },
+                ],
+              },
+            ],
+            generationConfig: {
+              responseMimeType: "application/json",
+              temperature: 0.5,
+              maxOutputTokens: 100,
+            },
+          }),
+        },
+      );
+      const data = await res.json();
+      console.log("📡 Gemini raw response:", data);
+      if (!res.ok) {
+        throw new Error(`Error ${res.status}`);
+      }
+      const content = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+      console.log("🔍 Contenido recibido:\n", content);
+      if (!content) {
+        throw new Error("Respuesta vacía del modelo");
+      }
+      const base = extractEmojis(content);
+      setEmojis(base);
+      const matrix = generateSymmetricPatternSymmetric(
+        base.length ? base : ["🧿"],
+        size,
+      );
+      setGrid(matrix);
+    } catch (err) {
+      console.error(err);
+      setError("No se pudo generar el diagnóstico");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Base dimension for the emoji grid itself
+  const gridSizeRem = size * 3 + (size - 1) * 0.5;
+  // Account for the card padding (p-4 -> 1rem on each side)
+  const cardSizeRem = gridSizeRem + 2;
+
+  return (
+    <main className="flex flex-col min-h-screen items-center p-6">
+      <div className="flex flex-col items-center justify-center flex-1 space-y-4 w-full">
+        {grid && (
+          <div
+            className="p-4 shadow-xl bg-gray-50 rounded-2xl flex items-center justify-center"
+            style={{ width: `${cardSizeRem}rem`, height: `${cardSizeRem}rem` }}
+          >
+            <EmojiGrid
+              grid={grid}
+              className="gap-2 text-5xl leading-none w-full h-full"
+            />
+          </div>
+        )}
+        <button
+          onClick={toggleSize}
+          className="px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600"
+        >
+          Cambiar tamaño: {size}x{size}
+        </button>
+        {error && <p className="text-red-500">{error}</p>}
+      </div>
+      <div className="w-full max-w-md mx-auto flex mt-4">
+        <textarea
+          className="flex-1 p-3 border rounded-l resize-none"
+          rows={3}
+          placeholder="Escribe algo..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleGenerate();
+            }
+          }}
+        />
+        <button
+          onClick={handleGenerate}
+          disabled={loading}
+          className="px-4 bg-blue-600 text-white rounded-r disabled:opacity-50"
+        >
+          {loading ? "..." : "⬆️"}
+        </button>
+      </div>
+      <Link
+        href="/"
+        className="fixed bottom-4 right-4 text-2xl p-2 bg-white rounded-full shadow hover:shadow-lg"
+      >
+        🏠
+      </Link>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,134 +1,34 @@
-"use client";
+import Link from 'next/link';
 
-import { useState, useEffect } from "react";
-import EmojiGrid from "@/components/EmojiGrid";
-import { extractEmojis } from "@/lib/toEmojiMatrix";
-import { generateSymmetricPatternSymmetric } from "@/lib/generateSymmetricPatternSymmetric";
+const options = [
+  {
+    title: 'Emoji Grids',
+    href: '/emojigrids',
+    emojis: ['😊', '☀️', '🔁', '📒'],
+  },
+  {
+    title: 'Emoji Translator',
+    href: '/translator',
+    emojis: ['💬', '✍️', '🌐', '🧠'],
+  },
+];
 
 export default function Home() {
-  const [text, setText] = useState("");
-  const [grid, setGrid] = useState<string[][] | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
-  const sizeOptions = [3, 5, 7];
-  const [sizeIndex, setSizeIndex] = useState(1); // default 5x5
-  const size = sizeOptions[sizeIndex];
-  const [emojis, setEmojis] = useState<string[]>([]);
-
-  const toggleSize = () => {
-    setSizeIndex((prev) => (prev + 1) % sizeOptions.length);
-  };
-
-  useEffect(() => {
-    if (emojis.length) {
-      const matrix = generateSymmetricPatternSymmetric(emojis, size);
-      setGrid(matrix);
-    }
-  }, [size, emojis]);
-
-  const handleGenerate = async () => {
-    if (!text.trim()) return;
-    setLoading(true);
-    setError("");
-    try {
-      const res = await fetch(
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=AIzaSyDnO8MO4qFgkOcSO2eHVZkfQ7cZ2KhrA5I",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            contents: [
-              {
-                parts: [
-                  {
-                    text: `Traduce el siguiente texto a la mayor cantidad posible de emojis apropiados. No expliques nada. Solo responde con emojis separados por espacios:\n\nTexto: ${text}`,
-                  },
-                ],
-              },
-            ],
-            generationConfig: {
-              responseMimeType: "application/json",
-              temperature: 0.5,
-              maxOutputTokens: 100,
-            },
-          }),
-        },
-      );
-      const data = await res.json();
-      console.log("📡 Gemini raw response:", data);
-      if (!res.ok) {
-        throw new Error(`Error ${res.status}`);
-      }
-      const content = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
-      console.log("🔍 Contenido recibido:\n", content);
-      if (!content) {
-        throw new Error("Respuesta vacía del modelo");
-      }
-      const base = extractEmojis(content);
-      setEmojis(base);
-      const matrix = generateSymmetricPatternSymmetric(
-        base.length ? base : ["🧿"],
-        size,
-      );
-      setGrid(matrix);
-    } catch (err) {
-      console.error(err);
-      setError("No se pudo generar el diagnóstico");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Base dimension for the emoji grid itself
-  const gridSizeRem = size * 3 + (size - 1) * 0.5;
-  // Account for the card padding (p-4 -> 1rem on each side)
-  const cardSizeRem = gridSizeRem + 2;
-
   return (
-    <main className="flex flex-col min-h-screen items-center p-6">
-      <div className="flex flex-col items-center justify-center flex-1 space-y-4 w-full">
-        {grid && (
-          <div
-            className="p-4 shadow-xl bg-gray-50 rounded-2xl flex items-center justify-center"
-            style={{ width: `${cardSizeRem}rem`, height: `${cardSizeRem}rem` }}
-          >
-            <EmojiGrid
-              grid={grid}
-              className="gap-2 text-5xl leading-none w-full h-full"
-            />
-          </div>
-        )}
-        <button
-          onClick={toggleSize}
-          className="px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600"
-        >
-          Cambiar tamaño: {size}x{size}
-        </button>
-        {error && <p className="text-red-500">{error}</p>}
-      </div>
-      <div className="w-full max-w-md mx-auto flex mt-4">
-        <textarea
-          className="flex-1 p-3 border rounded-l resize-none"
-          rows={3}
-          placeholder="Escribe algo..."
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
-              e.preventDefault();
-              handleGenerate();
-            }
-          }}
-        />
-        <button
-          onClick={handleGenerate}
-          disabled={loading}
-          className="px-4 bg-blue-600 text-white rounded-r disabled:opacity-50"
-        >
-          {loading ? "..." : "⬆️"}
-        </button>
+    <main className="min-h-screen flex items-center justify-center bg-white p-6">
+      <div className="flex flex-col gap-6 max-w-md w-full">
+        {options.map(({ title, href, emojis }) => (
+          <Link key={title} href={href} passHref>
+            <div className="flex items-center gap-4 border rounded-xl p-4 shadow hover:shadow-lg transition cursor-pointer bg-gray-50">
+              <div className="grid grid-cols-2 gap-1 text-2xl">
+                {emojis.map((emoji, idx) => (
+                  <div key={idx}>{emoji}</div>
+                ))}
+              </div>
+              <div className="text-xl font-semibold">{title}</div>
+            </div>
+          </Link>
+        ))}
       </div>
     </main>
   );

--- a/src/app/translator/page.tsx
+++ b/src/app/translator/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function TranslatorPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center relative text-center">
+      <h1 className="text-2xl font-bold mb-2">Emoji Translator</h1>
+      <p className="text-gray-500">Muy pronto podrás traducir cualquier texto a emojis.</p>
+      <Link
+        href="/"
+        className="fixed bottom-4 right-4 text-2xl p-2 bg-white rounded-full shadow hover:shadow-lg"
+      >
+        🏠
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add main index that links to Emoji Grids and Translator pages
- move existing functionality to `/emojigrids` and add home button
- create placeholder translator page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68587534033c832b802fc21f683a0df8