### PR TITLE
Add working emoji translator page

### DIFF
--- a/src/app/api/translate/route.ts
+++ b/src/app/api/translate/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const { prompt } = await req.json();
+    if (!prompt || typeof prompt !== 'string') {
+      return NextResponse.json({ error: 'Invalid prompt' }, { status: 400 });
+    }
+
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      // If no key, return simple mock to keep demo working
+      return NextResponse.json({ result: '🤖❓' });
+    }
+
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'Traduce la siguiente frase a una línea de emojis apropiados. No agregues texto, solo emojis separados por espacios.',
+          },
+          { role: 'user', content: prompt },
+        ],
+        temperature: 0.5,
+      }),
+    });
+
+    if (!res.ok) {
+      const message = await res.text();
+      return NextResponse.json({ error: message }, { status: res.status });
+    }
+
+    const data = await res.json();
+    const result = data.choices?.[0]?.message?.content?.trim() ?? '';
+    return NextResponse.json({ result });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/src/app/translator/page.tsx
+++ b/src/app/translator/page.tsx
@@ -1,10 +1,73 @@
-import Link from 'next/link';
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
 
 export default function TranslatorPage() {
+  const [text, setText] = useState("");
+  const [lines, setLines] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const send = async () => {
+    const prompt = text.trim();
+    if (!prompt) return;
+    setLoading(true);
+    setText("");
+    try {
+      const res = await fetch("/api/translate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ prompt }),
+      });
+      const data = await res.json();
+      if (res.ok && data.result) {
+        setLines((prev) => [...prev, String(data.result)]);
+      } else {
+        console.error(data);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center relative text-center">
-      <h1 className="text-2xl font-bold mb-2">Emoji Translator</h1>
-      <p className="text-gray-500">Muy pronto podrás traducir cualquier texto a emojis.</p>
+    <div className="min-h-screen flex flex-col items-center pt-8 pb-24 relative bg-white">
+      <h1 className="text-2xl font-bold mb-4">Emoji Translator</h1>
+      <div className="flex flex-col items-center w-full px-4 gap-4">
+        {lines.map((line, idx) => (
+          <div key={idx} className="text-center text-3xl leading-relaxed">
+            {line}
+          </div>
+        ))}
+      </div>
+      <div className="fixed bottom-4 left-0 right-0 px-4">
+        <div className="max-w-xl mx-auto flex bg-white shadow rounded-full overflow-hidden">
+          <input
+            type="text"
+            className="flex-1 px-4 py-2 outline-none rounded-l-full"
+            placeholder="Escribe algo..."
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                send();
+              }
+            }}
+          />
+          <button
+            onClick={send}
+            disabled={loading}
+            className="px-4 py-2 bg-blue-600 text-white rounded-r-full disabled:opacity-50"
+          >
+            {loading ? "..." : "Enviar"}
+          </button>
+        </div>
+      </div>
       <Link
         href="/"
         className="fixed bottom-4 right-4 text-2xl p-2 bg-white rounded-full shadow hover:shadow-lg"


### PR DESCRIPTION
## Summary
- implement /api/translate endpoint that calls OpenAI or returns a mock
- update translator page to send text to API and display emoji lines

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68587849cfc0832b9a68f8123f660c07