### PR TITLE
Implement emoji output cleaner

### DIFF
--- a/src/app/translator/page.tsx
+++ b/src/app/translator/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { cleanEmojiLine } from "@/lib/cleanEmojiLine";
 import Link from "next/link";
 
 export default function TranslatorPage() {
@@ -23,7 +24,8 @@ export default function TranslatorPage() {
       });
       const data = await res.json();
       if (res.ok && data.result) {
-        setLines((prev) => [...prev, String(data.result)]);
+        const cleaned = cleanEmojiLine(String(data.result));
+        setLines((prev) => [...prev, cleaned]);
       } else {
         console.error(data);
       }

--- a/src/lib/cleanEmojiLine.ts
+++ b/src/lib/cleanEmojiLine.ts
@@ -1,0 +1,5 @@
+import { extractEmojis } from './toEmojiMatrix';
+
+export function cleanEmojiLine(raw: string): string {
+  return extractEmojis(raw).join('');
+}


### PR DESCRIPTION
## Summary
- add `cleanEmojiLine` utility to return emojis without spaces or extra chars
- use this cleaner in Translator page to render sanitized lines

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68587c28129c832bb2a8e2929c84111a