### PR TITLE
Auto-confirm emoji input without pressing Enter

### DIFF
--- a/src/app/creator-grid/page.tsx
+++ b/src/app/creator-grid/page.tsx
@@ -177,9 +177,13 @@ export default function CreatorGridPage() {
                     <input
                       autoFocus={editing.value === ""}
                       value={editing.value}
-                      onChange={(e) =>
-                        setEditing({ ...editing, value: e.target.value.slice(0, 2) })
-                      }
+                      onChange={(e) => {
+                        const val = e.target.value.slice(0, 2);
+                        setEditing({ ...editing, value: val });
+                        if (Array.from(val).length >= 1) {
+                          setTimeout(() => confirmEdit(), 0);
+                        }
+                      }}
                       onBlur={confirmEdit}
                       onKeyDown={(e) => {
                         if (e.key === "Enter") {


### PR DESCRIPTION
## Summary
- automatically confirm cell edits in Creator Grid when a single emoji is entered

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685afd2bb214832bbc2d096a18d90f3e