### PR TITLE
Adjust width of global meaning box

### DIFF
--- a/src/app/creator-grid/page.tsx
+++ b/src/app/creator-grid/page.tsx
@@ -226,7 +226,7 @@ export default function CreatorGridPage() {
             }),
           )}
         </div>
-      <div className="relative p-3 border-2 border-gray-200 rounded bg-white min-h-[4rem] w-64">
+      <div className="relative p-3 border-2 border-gray-200 rounded bg-white min-h-[4rem] w-full max-w-[32rem]">
         <div className="whitespace-pre-wrap text-sm text-left">{globalMeaning}</div>
         <button
           onClick={copyMeaning}


### PR DESCRIPTION
## Summary
- widen the global meaning display on the creator grid

## Testing
- `npm run lint`
- `npm run build` *(fails: Type error in src/app/creator-grid/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_685b02309dac832b94ef599e91cdac53